### PR TITLE
Remove getClass() call in findAssertionBuilderTarget().

### DIFF
--- a/src/main/java/org/apache/neethi/AssertionBuilderFactoryImpl.java
+++ b/src/main/java/org/apache/neethi/AssertionBuilderFactoryImpl.java
@@ -146,7 +146,7 @@ public class AssertionBuilderFactoryImpl implements AssertionBuilderFactory {
                 return (Class<?>)pt.getActualTypeArguments()[0];
             }
         }
-        if (c.getClass().getSuperclass() != null) {
+        if (c.getSuperclass() != null) {
             return findAssertionBuilderTarget(c.getSuperclass());
         }
         return null;


### PR DESCRIPTION
c is already a Class object, calling getClass() on a Class object isn't intended here -- instead, the intention is to recursively find the super class from c.